### PR TITLE
feat: Add zoxide to Ansible setup and dotfiles

### DIFF
--- a/ansible/roles/laptop_setup/templates/dotfiles/.zshrc
+++ b/ansible/roles/laptop_setup/templates/dotfiles/.zshrc
@@ -386,6 +386,11 @@ fi
 # Mole shell completion
 if output="$(mole completion zsh 2>/dev/null)"; then eval "$output"; fi
 
+# Zoxide (smarter cd)
+if command -v zoxide &> /dev/null; then
+    eval "$(zoxide init zsh)"
+fi
+
 {| if integration_market_pay |}
 # Market Pay Platform Engineering Setup
 [ -s "${HOME}/.env" ] && source "${HOME}/.env"

--- a/ansible/roles/master_setup/defaults/main.yml
+++ b/ansible/roles/master_setup/defaults/main.yml
@@ -76,6 +76,7 @@ master_setup_global_packages_apt:
   - wdiff
   - "{{ 'yq' if not master_setup_is_debian_lower_12 else omit }}"
   - zip
+  - zoxide
   - zsh
 # Only for Debian < 12
 master_setup_global_packages_pip_system:

--- a/ansible/roles/master_setup/templates/dotfiles/.zshrc
+++ b/ansible/roles/master_setup/templates/dotfiles/.zshrc
@@ -165,5 +165,10 @@ alias gctx=gcloudctx
 # Direnv activation
 command -v direnv &> /dev/null && eval "$(direnv hook zsh)"
 
+# Zoxide (smarter cd)
+if command -v zoxide &> /dev/null; then
+    eval "$(zoxide init zsh)"
+fi
+
 # iTerm2 integration
 test -e "${HOME}/.iterm2_shell_integration.zsh" && source "${HOME}/.iterm2_shell_integration.zsh"

--- a/ansible/vars/laptop.yml
+++ b/ansible/vars/laptop.yml
@@ -200,6 +200,7 @@ laptop_setup_homebrew_packages:
   - "{{ 'yamllint' if integration_market_pay else omit }}"
   - yarn
   - yq
+  - zoxide
 homebrew_cask_packages:
   - "{{ 'bitwarden' if integration_market_pay else omit }}"
   - git-credential-manager
@@ -250,6 +251,7 @@ laptop_setup_global_apt_packages:
   - wdiff
   - whois
   - zip
+  - zoxide
   - zsh
 
 iterm2_library_path: ~/Library/Application Support/iTerm2


### PR DESCRIPTION
This PR introduces `zoxide` (a smarter cd) into the environment.
- Added `zoxide` to laptop homebrew and apt packages.
- Added `zoxide` to master server apt packages.
- Updated `.zshrc` templates (both laptop and master setups) to automatically initialize zoxide if installed.